### PR TITLE
Support DPO training for Qwen2-VL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,11 @@ llamafactory-cli train examples/train_lora/qwen2vl_lora_sft.yaml
 llamafactory-cli export examples/merge_lora/qwen2vl_lora_sft.yaml
 ```
 
+LoRA DPO/ORPO/SimPO examples:
+```
+llamafactory-cli train examples/train_lora/qwen2vl_lora_dpo.yaml
+```
+
 Full SFT examples:
 ```
 llamafactory-cli train examples/train_full/qwen2vl_full_sft.yaml

--- a/README.md
+++ b/README.md
@@ -1305,7 +1305,7 @@ llamafactory-cli train examples/train_lora/qwen2vl_lora_sft.yaml
 llamafactory-cli export examples/merge_lora/qwen2vl_lora_sft.yaml
 ```
 
-LoRA DPO/ORPO/SimPO examples:
+LoRA DPO/ORPO/SimPO examples: (using [RLHF-V Dataset](https://huggingface.co/datasets/llamafactory/RLHF-V))
 ```
 llamafactory-cli train examples/train_lora/qwen2vl_lora_dpo.yaml
 ```


### PR DESCRIPTION
LLaMA Factory has supported DPO, ORPO and SimPO training for Qwen2-VL models, we add training recipes for this

Dataset: https://huggingface.co/datasets/llamafactory/RLHF-V

![image](https://github.com/user-attachments/assets/37cfe5bd-9ee5-4aae-86c5-3bcd2ed9e14b)
