### PR TITLE
Corrected model paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,7 +807,7 @@ from qwen_vl_utils import process_vision_info
 
 # We recommend enabling flash_attention_2 for better acceleration and memory saving, especially in multi-image and video scenarios.
 # model = Qwen2VLForConditionalGeneration.from_pretrained(
-#     "Qwen2-VL-7B-Instruct-GPTQ-Int4",
+#     "Qwen/Qwen2-VL-7B-Instruct-GPTQ-Int4",
 #     torch_dtype=torch.bfloat16,
 #     attn_implementation="flash_attention_2",
 #     device_map="auto",
@@ -815,14 +815,14 @@ from qwen_vl_utils import process_vision_info
 
 # default: Load the model on the available device(s)
 model = Qwen2VLForConditionalGeneration.from_pretrained(
-    "Qwen2-VL-7B-Instruct-GPTQ-Int4", torch_dtype="auto", device_map="auto"
+    "Qwen/Qwen2-VL-7B-Instruct-GPTQ-Int4", torch_dtype="auto", device_map="auto"
 )
 
 # The default range for the number of visual tokens per image in the model is 4-16384. You can set min_pixels and max_pixels according to your needs, such as a token count range of 256-1280, to balance speed and memory usage.
 min_pixels = 256 * 28 * 28
 max_pixels = 1280 * 28 * 28
 processor = AutoProcessor.from_pretrained(
-    "Qwen2-VL-7B-Instruct-GPTQ-Int4", min_pixels=min_pixels, max_pixels=max_pixels
+    "Qwen/Qwen2-VL-7B-Instruct-GPTQ-Int4", min_pixels=min_pixels, max_pixels=max_pixels
 )
 
 messages = [


### PR DESCRIPTION
The GPTQ section the README incorrectly had `Qwen2-VL-7B-Instruct-GPTQ-Int4` as the model url instead of `Qwen/Qwen2-VL-7B-Instruct-GPTQ-Int4`