### PR TITLE
修改MTVQA计算平均分的方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We opensourced Qwen2-VL-2B and Qwen2-VL-7B with Apache 2.0 license, and we relea
 | ChartQA<sub>test</sub>  | 88.4 | **90.8** | 85.7 | 88.3 |83.0| 73.5
 | TextVQA<sub>val</sub>  | 84.4 | - | - | **85.5** |84.3|79.7
 | OCRBench | 852 | 788 | 736 | **855** |845| 794
-| MTVQA | 17.3 | 25.7 | 27.8 | **32.6** |26.3| 20.0
+| MTVQA | 17.3 | 25.7 | 27.8 | **30.9** |25.6| 18.1
 | RealWorldQA | 72.2 | 60.1 | 75.4 | **77.8** | 70.1| 62.9
 | MME<sub>sum</sub>   | 2414.7 | 1920.0 | 2328.7 | **2482.7** | 2326.8 | 1872.0
 | MMBench-EN<sub>test</sub>  | **86.5** | 79.7 | 83.4 | **86.5** | 83.0 | 74.9
@@ -129,7 +129,7 @@ SR, GC, TM and EM are short for success rate, goal-condition success, type match
         <td>15.6 </td>
         <td>17.7 </td>
         <td>41.6 </td>
-        <td><b>32.6</b></td>
+        <td><b>30.9</b></td>
     </tr>
     <tr>
         <th align="left">GPT-4o</th>


### PR DESCRIPTION
MTVQA的平均分是根据各个语种的分数平均出来的，不是按照sample数量来平均的