### PR TITLE
Update vLLM install instructions to fix pip error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,7 +1084,7 @@ cd vllm
 git checkout add_qwen2_vl_new
 # Change to your CUDA version
 CUDA_VERSION=cu121
-pip install . --index-url https://download.pytorch.org/whl/${CUDA_VERSION}
+pip install . --extra-index-url https://download.pytorch.org/whl/${CUDA_VERSION}
 ```
 ### Start an OpenAI API Service
 


### PR DESCRIPTION
I was hitting a cmake version issue when installing- PyTorch only has cmake 3.25 and some other parts of the install wants >= 3.26. So switched PyTorch's index to extra-index-url.