### PR TITLE
Multiturn chat demo 多轮对话的示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ model = Qwen2VLForConditionalGeneration.from_pretrained(
 ```
 
 ### Multi-turn Conversation
-There is an easy way to use Qwen2-VL for multi-turn conversation which supports pure text, single image, multi-images. You can use it as follows:
+There is an easy way to use Qwen2-VL for multi-turn conversations which supports pure text, single image, multi-images. You can use it as follows:
 
 First copy the class `Qwen2VL`.
 ```python
@@ -676,7 +676,7 @@ class Qwen2VL:
         gc.collect()
         return response, history
 ```
-Then use the `chat` API in `Qwen2VL` class.
+Then use the `chat` API in `Qwen2VL` class, `query` parameter is the user query in natural language format, `imgs` parameter is the image url or path or base64, `history` parameter is the history of the conversation.
 ```python
 chat_model = Qwen2VL(model_path="local path/repo id")
 


### PR DESCRIPTION
# 主要贡献
- 修改readme中没有多轮对话示例的问题
- 将所有的推理代码封装成类的形式，提升封装性

# 具体工作
设计了Qwen2VL类，将推理代码进一步的封装，
用户只需要通过传递自然语言形式的query、图片的路径imgs、前文的对话history给`chat`接口，就可以完成多轮对话。简单如下：
```python
chat_model = Qwen2VL(model_path="local path/repo id")

# First turn
history = None
response, history = chat_model.chat(query="hello", history=history)
print(response, history)

# Second turn
# For image type, (imgae_url, local_image_path, base64)
# For image count, ([image], [image1, image2], ...)
response, history = chat_model.chat(query="please describe the image", imgs=["image_url"], history=history)
print(response, history)
```
对于新手小白会更加友好，无需关心如何构造messages，就跟我们跟gpt打交道一样，用自然语言表述我们的需求、在浏览器端上传图片，同时保留历史对话。

# 自我介绍
最后小小的自我介绍一下，我是一名浙江大学的研究生，同时也在淘天集团的大模型岗位实习过，主要工作集中在多模态大模型，对`Qwen2VL`，`QwenVL`，`InternVL`比较熟悉，因为学校开设的开源课程，对开源社区贡献比较感兴趣，第一次提交pr，无论是否被merge，都算是一次勇敢的尝试哈哈