### PR TITLE
Qwen2-VL is supported in  PaddleMIX by Paddle Team.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ We have open-sourced Qwen2-VL models, including Qwen2-VL-2B and Qwen2-VL-7B unde
 
 
 ## News
+* 2024.10.11:🚀🚀🚀 [Qwen2-VL](https://github.com/PaddlePaddle/PaddleMIX/blob/develop/paddlemix/examples/qwen2_vl)  is supported in  [PaddleMIX](https://github.com/PaddlePaddle/PaddleMIX) by Paddle Team. 
 * 2024.09.19: The instruction-tuned [Qwen2-VL-72B model](https://huggingface.co/Qwen/Qwen2-VL-72B-Instruct) and its quantized version [[AWQ](https://huggingface.co/Qwen/Qwen2-VL-72B-Instruct-AWQ), [GPTQ-Int4](https://huggingface.co/Qwen/Qwen2-VL-72B-Instruct-GPTQ-Int4), [GPTQ-Int8](https://huggingface.co/Qwen/Qwen2-VL-72B-Instruct-GPTQ-Int8)] are now available. We have also released the [Qwen2-VL paper](https://arxiv.org/pdf/2409.12191) simultaneously.
 * 2024.08.30: We have released the [Qwen2-VL series]("https://huggingface.co/collections/Qwen/qwen2-vl-66cee7455501d7126940800d). The 2B and 7B models are now available, and the 72B model for opensource is coming soon. For more details, please check our [blog](https://qwenlm.github.io/blog/qwen2-vl/)!
 


### PR DESCRIPTION
* [2024.10.11 ]  Thanks to all the authors for their great work!
🚀🚀🚀 [Qwen2-VL](https://github.com/PaddlePaddle/PaddleMIX/blob/develop/paddlemix/examples/qwen2_vl)  is supported in  [PaddleMIX](https://github.com/PaddlePaddle/PaddleMIX) by Paddle Team. Welcome everyone to try it out!